### PR TITLE
Update docblocks with official documentation

### DIFF
--- a/src/RequestHandlerInterface.php
+++ b/src/RequestHandlerInterface.php
@@ -6,13 +6,17 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * An HTTP request handler process a HTTP request and produces an HTTP response.
- * This interface defines the methods required to use the request handler.
+ * Handles a server request and produces a response.
+ *
+ * An HTTP request handler process an HTTP request in order to produce an
+ * HTTP response.
  */
 interface RequestHandlerInterface
 {
     /**
-     * Handle the request and return a response.
+     * Handles a request and produces a response.
+     *
+     * May call other collaborating code to generate the response.
      */
     public function handle(ServerRequestInterface $request): ResponseInterface;
 }


### PR DESCRIPTION
Interface documentation was not updated after PSR-15 was approved, which makes these interfaces out of sync with the accepted specification.

Refs php-fig/fig-standards#1107