### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 HTTP Server Request Handlers for Middleware
-==============
+===========================================
 
 This repository holds the `RequestHandlerInterface` related to [PSR-15 (HTTP Server Request Handlers)][psr-url].
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-HTTP Server Handler
-===================
+HTTP Server Request Handlers
+==============
 
-Provides the `RequestHandlerInterface` of [PSR-15][psr-15].
+This repository holds all interfaces related to [PSR-15 (HTTP Server Request Handlers)][psr-url].
 
-[psr-15]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-15-request-handlers.md
+Note that this is not an HTTP Server Request Handler implementation of its own. It is merely interfaces that describe the components of one.
+
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+
+[psr-url]: https://www.php-fig.org/psr/psr-15/
+[package-url]: https://packagist.org/packages/psr/http-server-handler
+[implementation-url]: https://packagist.org/providers/psr/http-server-handler-implementation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HTTP Server Request Handlers
+HTTP Server Request Handlers for Middleware
 ==============
 
 This repository holds the `RequestHandlerInterface` related to [PSR-15 (HTTP Server Request Handlers)][psr-url].

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds the `RequestHandlerInterface` related to [PSR-15 (HTTP Ser
 
 Note that this is not a Server Request Handler implementation of its own. It is merely the interface that describe a Server Request Handler.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: https://www.php-fig.org/psr/psr-15/
 [package-url]: https://packagist.org/packages/psr/http-server-handler

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 HTTP Server Request Handlers
 ==============
 
-This repository holds all interfaces related to [PSR-15 (HTTP Server Request Handlers)][psr-url].
+This repository holds the `RequestHandlerInterface` related to [PSR-15 (HTTP Server Request Handlers)][psr-url].
 
-Note that this is not an HTTP Server Request Handler implementation of its own. It is merely interfaces that describe the components of one.
+Note that this is not a Server Request Handler implementation of its own. It is merely the interface that describe a Server Request Handler.
 
 You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
 


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.