### PR TITLE
PHP5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,17 @@
         {
             "name": "PHP-FIG",
             "homepage": "https://www.php-fig.org/"
-        }
+        },
+	{
+	    "name": "Sarigue",
+	    "homepage": "https://github.com/sarigue/"
+	}
     ],
     "support": {
         "source": "https://github.com/php-fig/http-server-handler"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=5.6",
         "psr/http-message": "^1.0 || ^2.0"
     },
     "autoload": {

--- a/src/RequestHandlerInterface.php
+++ b/src/RequestHandlerInterface.php
@@ -17,6 +17,8 @@ interface RequestHandlerInterface
      * Handles a request and produces a response.
      *
      * May call other collaborating code to generate the response.
+     *
+     * @return ResponseInterface
      */
-    public function handle(ServerRequestInterface $request): ResponseInterface;
+    public function handle(ServerRequestInterface $request);
 }


### PR DESCRIPTION
PHP 5.6 is an older version of PHP, but it's still sometimes used...
Also, a PHP 5.6-compatible version of the PSR interfaces can be useful.
I propose an "old-version" new branch with the tag 0.9